### PR TITLE
Add ability to 'even out' logs

### DIFF
--- a/Sources/FileLogger.swift
+++ b/Sources/FileLogger.swift
@@ -34,7 +34,7 @@ struct FileLogger {
 
 	fileprivate init(){}
 
-	func filelog(priority: String, _ args: String, _ eventid: String, _ logFile: String) {
+	func filelog(priority: String, _ args: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		let m = moment()
 		var useFile = logFile
 		if logFile.isEmpty { useFile = defaultFile }
@@ -44,38 +44,38 @@ struct FileLogger {
 			try ff.open(.append)
 			try ff.write(string: "\(priority) [\(eventid)] [\(m.format())] \(args)\n")
 		} catch {
-			consoleEcho.critical(message: "\(error)")
+			consoleEcho.critical(message: "\(error)", even)
 		}
 	}
 
 	func debug(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.debug(message: message)
-		filelog(priority: even ? "[DEBUG]" : "[DEBUG]", message, eventid, logFile)
+		consoleEcho.debug(message: message, even)
+		filelog(priority: even ? "[DEBUG]" : "[DEBUG]", message, eventid, logFile, even)
 	}
 
 	func info(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.info(message: message)
-		filelog(priority: even ? "[INFO] " : "[INFO]", message, eventid, logFile)
+		consoleEcho.info(message: message, even)
+		filelog(priority: even ? "[INFO] " : "[INFO]", message, eventid, logFile, even)
 	}
 
 	func warning(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.warning(message: message)
-		filelog(priority: even ? "[WARN] " : "[WARNING]", message, eventid, logFile)
+		consoleEcho.warning(message: message, even)
+		filelog(priority: even ? "[WARN] " : "[WARNING]", message, eventid, logFile, even)
 	}
 
 	func error(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.error(message: message)
-		filelog(priority: even ? "[ERROR]" : "[ERROR]", message, eventid, logFile)
+		consoleEcho.error(message: message, even)
+		filelog(priority: even ? "[ERROR]" : "[ERROR]", message, eventid, logFile, even)
 	}
 
 	func critical(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.critical(message: message)
-		filelog(priority: even ? "[CRIT] " : "[CRITICAL]", message, eventid, logFile)
+		consoleEcho.critical(message: message, even)
+		filelog(priority: even ? "[CRIT] " : "[CRITICAL]", message, eventid, logFile, even)
 	}
 
 	func terminal(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
-		consoleEcho.terminal(message: message)
-		filelog(priority: even ? "[EMERG]" : "[EMERG]", message, eventid, logFile)
+		consoleEcho.terminal(message: message, even)
+		filelog(priority: even ? "[EMERG]" : "[EMERG]", message, eventid, logFile, even)
 	}
 }
 

--- a/Sources/FileLogger.swift
+++ b/Sources/FileLogger.swift
@@ -48,34 +48,34 @@ struct FileLogger {
 		}
 	}
 
-	func debug(message: String, _ eventid: String, _ logFile: String) {
+	func debug(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.debug(message: message)
-		filelog(priority: "[DEBUG]", message, eventid, logFile)
+		filelog(priority: even ? "[DEBUG]" : "[DEBUG]", message, eventid, logFile)
 	}
 
-	func info(message: String, _ eventid: String, _ logFile: String) {
+	func info(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.info(message: message)
-		filelog(priority: "[INFO]", message, eventid, logFile)
+		filelog(priority: even ? "[INFO] " : "[INFO]", message, eventid, logFile)
 	}
 
-	func warning(message: String, _ eventid: String, _ logFile: String) {
+	func warning(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.warning(message: message)
-		filelog(priority: "[WARNING]", message, eventid, logFile)
+		filelog(priority: even ? "[WARN] " : "[WARNING]", message, eventid, logFile)
 	}
 
-	func error(message: String, _ eventid: String, _ logFile: String) {
+	func error(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.error(message: message)
-		filelog(priority: "[ERROR]", message, eventid, logFile)
+		filelog(priority: even ? "[ERROR]" : "[ERROR]", message, eventid, logFile)
 	}
 
-	func critical(message: String, _ eventid: String, _ logFile: String) {
+	func critical(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.critical(message: message)
-		filelog(priority: "[CRITICAL]", message, eventid, logFile)
+		filelog(priority: even ? "[CRIT] " : "[CRITICAL]", message, eventid, logFile)
 	}
 
-	func terminal(message: String, _ eventid: String, _ logFile: String) {
+	func terminal(message: String, _ eventid: String, _ logFile: String, _ even: Bool) {
 		consoleEcho.terminal(message: message)
-		filelog(priority: "[EMERG]", message, eventid, logFile)
+		filelog(priority: even ? "[EMERG]" : "[EMERG]", message, eventid, logFile)
 	}
 }
 
@@ -88,6 +88,10 @@ public struct LogFile {
 	/// The location of the log file.
 	/// The default location is relative, "log.log"
 	public static var location = "./log.log"
+	
+	/// Whether or not to even off the log messages
+	/// If set to true log messages will be inline with each other
+	public static var even = false
 
 	/// Logs a [DEBUG] message to the log file.
 	/// Also echoes the message to the console.
@@ -95,8 +99,8 @@ public struct LogFile {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func debug(_ message: @autoclosure () -> String, eventid: String = UUID().string, logFile: String = location) -> String {
-		LogFile.logger.debug(message: message(), eventid, logFile)
+	public static func debug(_ message: @autoclosure () -> String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> String {
+		LogFile.logger.debug(message: message(), eventid, logFile, evenIdents)
 		return eventid
 	}
 
@@ -106,8 +110,8 @@ public struct LogFile {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func info(_ message: String, eventid: String = UUID().string, logFile: String = location) -> String {
-		LogFile.logger.info(message: message, eventid, logFile)
+	public static func info(_ message: String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> String {
+		LogFile.logger.info(message: message, eventid, logFile, evenIdents)
 		return eventid
 	}
 
@@ -117,8 +121,8 @@ public struct LogFile {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func warning(_ message: String, eventid: String = UUID().string, logFile: String = location) -> String {
-		LogFile.logger.warning(message: message, eventid, logFile)
+	public static func warning(_ message: String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> String {
+		LogFile.logger.warning(message: message, eventid, logFile, evenIdents)
 		return eventid
 	}
 
@@ -128,8 +132,8 @@ public struct LogFile {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func error(_ message: String, eventid: String = UUID().string, logFile: String = location) -> String {
-		LogFile.logger.error(message: message, eventid, logFile)
+	public static func error(_ message: String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> String {
+		LogFile.logger.error(message: message, eventid, logFile, evenIdents)
 		return eventid
 	}
 
@@ -139,8 +143,8 @@ public struct LogFile {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func critical(_ message: String, eventid: String = UUID().string, logFile: String = location) -> String {
-		LogFile.logger.critical(message: message, eventid, logFile)
+	public static func critical(_ message: String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> String {
+		LogFile.logger.critical(message: message, eventid, logFile, evenIdents)
 		return eventid
 	}
 
@@ -148,8 +152,8 @@ public struct LogFile {
 	/// Also echoes the message to the console.
 	/// Specifiy a logFile parameter to direct the logging to a file other than the default.
 	/// Takes an optional "eventid" param, which helps to link related events together.
-	public static func terminal(_ message: String, eventid: String = UUID().string, logFile: String = location) -> Never  {
-		LogFile.logger.terminal(message: message, eventid, logFile)
+	public static func terminal(_ message: String, eventid: String = UUID().string, logFile: String = location, evenIdents: Bool = even) -> Never  {
+		LogFile.logger.terminal(message: message, eventid, logFile, evenIdents)
 		fatalError(message)
 	}
 }

--- a/Sources/RemoteLogger.swift
+++ b/Sources/RemoteLogger.swift
@@ -28,7 +28,11 @@ public struct RemoteLogger {
 	public static var logServer = "http://localhost:8100"
 	public static var token = ""
 	public static var appid = ""
-
+	
+	/// Whether or not to even off the log messages
+	/// If set to true log messages will be inline with each other
+	public static var even = false
+	
 	static let consoleEcho = ConsoleLogger()
 
 	fileprivate init(){}
@@ -103,12 +107,12 @@ public struct RemoteLogger {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func debug(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> String {
+	public static func debug(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> String {
 		do {
-			consoleEcho.debug(message: try detail.jsonEncodedString())
+			consoleEcho.debug(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "debug", detail, eventid)
 		} catch {
-			consoleEcho.error(message: "\(error)")
+			consoleEcho.error(message: "\(error)", evenIdents)
 		}
 		return eventid
 	}
@@ -119,12 +123,12 @@ public struct RemoteLogger {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func info(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> String {
+	public static func info(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> String {
 		do {
-			consoleEcho.info(message: try detail.jsonEncodedString())
+			consoleEcho.info(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "info", detail, eventid)
 		} catch {
-			consoleEcho.error(message: "\(error)")
+			consoleEcho.error(message: "\(error)", evenIdents)
 		}
 		return eventid
 	}
@@ -135,12 +139,12 @@ public struct RemoteLogger {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func warning(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> String {
+	public static func warning(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> String {
 		do {
-			consoleEcho.warning(message: try detail.jsonEncodedString())
+			consoleEcho.warning(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "warning", detail, eventid)
 		} catch {
-			consoleEcho.error(message: "\(error)")
+			consoleEcho.error(message: "\(error)", evenIdents)
 		}
 		return eventid
 	}
@@ -151,12 +155,12 @@ public struct RemoteLogger {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func error(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> String {
+	public static func error(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> String {
 		do {
-			consoleEcho.error(message: try detail.jsonEncodedString())
+			consoleEcho.error(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "error", detail, eventid)
 		} catch {
-			consoleEcho.error(message: "\(error)")
+			consoleEcho.error(message: "\(error)", evenIdents)
 		}
 		return eventid
 	}
@@ -167,12 +171,12 @@ public struct RemoteLogger {
 	/// Takes an optional "eventid" param, which helps to link related events together.
 	/// Returns an eventid string. If one was supplied, it will be echoed back, else a new one will be generated for reuse.
 	@discardableResult
-	public static func critical(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> String {
+	public static func critical(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> String {
 		do {
-			consoleEcho.critical(message: try detail.jsonEncodedString())
+			consoleEcho.critical(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "critical", detail, eventid)
 		} catch {
-			consoleEcho.error(message: "\(error)")
+			consoleEcho.error(message: "\(error)", evenIdents)
 		}
 		return eventid
 	}
@@ -181,9 +185,9 @@ public struct RemoteLogger {
 	/// Also echoes the message to the console.
 	/// Specifiy a logFile parameter to direct the logging to a file other than the default.
 	/// Takes an optional "eventid" param, which helps to link related events together.
-	public static func terminal(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string) -> Never {
+	public static func terminal(_ detail: [String:Any] = [String:Any](), eventid: String = UUID().string, evenIdents: Bool = even) -> Never {
 		do {
-			consoleEcho.critical(message: try detail.jsonEncodedString())
+			consoleEcho.critical(message: try detail.jsonEncodedString(), evenIdents)
 			try RemoteLogger.log(priority: "emerg", detail, eventid)
 			let str = try detail.jsonEncodedString()
 			fatalError(str)
@@ -192,4 +196,3 @@ public struct RemoteLogger {
 		}
 	}
 }
-


### PR DESCRIPTION
If you read log files in plaintext, like I do, having the lines be different lengths is annoying. This adds an opt-in way to make the log messages flush with each other:

even = false (default)
```
[INFO] [6f571b25-87d1-4a6a-94cc-b43ccbfc3321] [2017-07-01 13:00:48 GMT-05:00] Starting server in mode 'debug'
[INFO] [5dcb283e-598b-46f7-8bc1-8402080926d3] [2017-07-01 13:00:48 GMT-05:00] mustacheRoot: /Users/[redacted]/Desktop/Programming/Swift/Perfect/[redacted]/Web/templates/public
[INFO] [ee6e93f4-d92c-4b20-bf1d-6cf044c28e0c] [2017-07-01 13:00:48 GMT-05:00] Starting [redacted] core...
[INFO] [d6cdf590-9cf9-4440-9faa-dd97e9fc8117] [2017-07-01 13:00:48 GMT-05:00] Initializing StORM
[ERROR] [d6cdf590-9cf9-4440-9faa-dd97e9fc8117] [2017-07-01 13:00:48 GMT-05:00] The operation couldn’t be completed. (MongoDB.BSONError error 0.)
[INFO] [ee6e93f4-d92c-4b20-bf1d-6cf044c28e0c] [2017-07-01 13:00:48 GMT-05:00] Starting server...
```

even = true
```
[INFO]  [4b8fa103-9c4e-45de-aadf-bfd193475def] [2017-07-01 12:39:35 GMT-05:00] Starting server in mode 'debug'
[INFO]  [a10174bf-3dc6-44b0-847d-19fde5ed176a] [2017-07-01 12:39:35 GMT-05:00] mustacheRoot: /Users/[redacted]/Desktop/Programming/Swift/Perfect/[redacted]/Web/templates/public
[INFO]  [1c17aa3a-758f-44b3-ab92-c3bf7729d5d8] [2017-07-01 12:39:35 GMT-05:00] Starting [redacted] core...
[INFO]  [ce4e4dae-32dc-4052-9947-6e1c8c75848e] [2017-07-01 12:39:35 GMT-05:00] Initializing StORM
[ERROR] [ce4e4dae-32dc-4052-9947-6e1c8c75848e] [2017-07-01 12:39:35 GMT-05:00] The operation couldn’t be completed. (MongoDB.BSONError error 0.)
[INFO]  [1c17aa3a-758f-44b3-ab92-c3bf7729d5d8] [2017-07-01 12:39:35 GMT-05:00] Starting server...
```

Note: PerfectlySoft/Perfect#238 *must* be pulled first. This *will not* work without that pulled first