### PR TITLE
Log threshold and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ returns:
 The returned eventid is marked `@discardableResult` therefore can be safely ignored if not required for re-use.
 
 
-## Setting a custom Logfile location
+## Customization
+
+### Setting a custom Logfile location
 
 The default logfile location is `./log.log`. To set a custom logfile location, set the `LogFile.location` variable:
 
@@ -107,6 +109,54 @@ LogFile.error("error message")
 LogFile.critical("critical message")
 LogFile.terminal("terminal message")
 ```
+
+### LogFile threshold
+
+For debug purposes, you want to see as much info as available. However, on production servers you probably desire a
+smaller logfile and filter out all redundant info.
+
+To do so, you may set the LogFile's `threshold` property to the minumum priority you want to actually being logged into the file.
+
+e.g.:
+
+```swift
+LogFile.threshold = .warning
+LogFile.debug("This won't be logged into the file")
+LogFile.info("This won't be logged into the file")
+LogFile.warning("This will be logged into the file")
+LogFile.error("This will be logged into the file")
+LogFile.critical("This will be logged into the file")
+```
+
+The default value of this property is `.debug` to preserve backward compatibility and this property will not affect the Console/Remote logger.
+
+### LogFile options
+
+Depending on your needs, you may not be interested in an event id, timestamp or priority.
+
+Using the LogFile's `options` property you can customize which of those fields will actually be added as a prefix to the log message.
+
+e.g.:
+
+```swift
+// Default behaviour (equal to `[.priority, .eventId, .timestamp]`)
+LogFile.options = .default
+LogFile.debug("This is my log message")
+// Will log: "[DEBUG] [CEC5B5DB-931F-4C5A-A794-17D060BABC80] [2019-05-04 15:16:11 GMT+02:00] This is my log message"
+
+LogFile.options = .none
+LogFile.debug("This is my log message")
+// Will log: "This is my log message"
+
+LogFile.options = [.priority, .timestamp]
+LogFile.debug("This is my log message")
+// Will log: "[DEBUG] [2019-05-04 15:16:11 GMT+02:00] This is my log message"
+
+LogFile.options = [.priority]
+LogFile.debug("This is my log message")
+// Will log: "[DEBUG] This is my log message"
+```
+
 
 ## Sample output
 

--- a/Sources/PerfectLogger/FileLogger.swift
+++ b/Sources/PerfectLogger/FileLogger.swift
@@ -136,7 +136,7 @@ public struct LogFile {
      LogFile.options = [.level, .timestamp]
      ```
      */
-    public static var option: LogOptions {
+    public static var options: LogOptions {
         get {
             return logger.options
         }

--- a/Sources/PerfectLogger/LogOptions.swift
+++ b/Sources/PerfectLogger/LogOptions.swift
@@ -1,0 +1,53 @@
+//
+//  LogOptions.swift
+//  PerfectLogger
+//
+//  Created by Michiel Horvers on 04/05/2019.
+//    Copyright (C) 2019 PerfectlySoft, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Perfect.org open source project
+//
+// Copyright (c) 2015 - 2019 PerfectlySoft Inc. and the Perfect project authors
+// Licensed under Apache License v2.0
+//
+// See http://perfect.org/licensing.html for license information
+//
+//===----------------------------------------------------------------------===//
+//
+
+import Foundation
+
+public struct LogOptions: OptionSet {
+    /// Rawvalue of this option set
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /*
+     * MARK: Default sets
+     */
+
+    /// Default option set
+    public static let `default`: LogOptions = [.priority, .eventId, .timestamp]
+
+    /// Will only log the message itself
+    public static let none: LogOptions = []
+
+    /*
+     * MARK: Options
+     */
+
+    /// Logs the level/priority (e.g. "[DEBUG]")
+    public static let priority  = LogOptions(rawValue: 1 << 0)
+
+    /// Logs the event ID (e.g. "[34E621FD-9A57-47A0-BD3A-1B432B77BA30]")
+    public static let eventId   = LogOptions(rawValue: 1 << 1)
+
+    /// Logs the timestamp (e.g. "[2019-05-04 13:25:55 GMT+02:00]")
+    public static let timestamp = LogOptions(rawValue: 1 << 2)
+
+}

--- a/Sources/PerfectLogger/LogPriority.swift
+++ b/Sources/PerfectLogger/LogPriority.swift
@@ -1,0 +1,74 @@
+//
+//  LogPriority.swift
+//  PerfectLogger
+//
+//  Created by Michiel Horvers on 04/05/2019.
+//    Copyright (C) 2019 PerfectlySoft, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Perfect.org open source project
+//
+// Copyright (c) 2015 - 2019 PerfectlySoft Inc. and the Perfect project authors
+// Licensed under Apache License v2.0
+//
+// See http://perfect.org/licensing.html for license information
+//
+//===----------------------------------------------------------------------===//
+//
+
+
+import Foundation
+
+/**
+ Priority of the message.
+
+ Either one of:
+ * debug
+ * info
+ * warning
+ * error
+ * critical
+ * terminal
+ 
+ */
+public enum LogPriority: Int {
+    case debug
+    case info
+    case warning
+    case error
+    case critical
+    case terminal
+}
+
+internal extension LogPriority {
+    /**
+     Returns the string representation for this level.
+
+     If `even` set to true,  log messages will be inline with each other
+
+     - parameter even: Whether or not to even off the log messages
+
+     - returns: The string representation for this log level
+     */
+    func stringRepresentation(even: Bool) -> String {
+        switch self {
+        case .debug:    return "[DEBUG]"
+        case .info:     return even ? "[INFO] " : "[INFO]"
+        case .warning:  return even ? "[WARN] " : "[WARNING]"
+        case .error:    return "[ERROR]"
+        case .critical: return even ? "[CRIT] " : "[CRITICAL]"
+        case .terminal: return even ? "[EMERG]" : "[EMERG]"
+        }
+    }
+}
+
+extension LogPriority: Comparable {
+    public static func >(lhs: LogPriority, rhs: LogPriority) -> Bool {
+        return lhs.rawValue > rhs.rawValue
+    }
+
+    public static func <(lhs: LogPriority, rhs: LogPriority) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+}


### PR DESCRIPTION
This PR will add two features to Perfect-Logger:

**Log Threshold**
When debugging, you want to log as much info as possible. However, on a production server you probably desire a smaller logfile and won't be interested into debug information.

To do so, I added the property `threshold` to LogFile, which will filter out all logs that are **lower** than the threshold (e.g. `warning` will log warning, error, critical and terminal, but filter out debug and info)

The default value is `.debug` to preserve backward compatibility.
This property will not affect the console and remote logger.

**Log Options**
Depending on your needs, you may not be interested in an event id, or (less likely, but still) timestamp or priority.

By setting the LogFile's `options` property one can specify which of those fields he actually want to see in the log.

Also this property is by default set to all fields, to preserve backward compatibility.

Please see the updated README for more info and actual examples.